### PR TITLE
Include number of openmp threads in the metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "scope-profiler"
-version = "0.2"
+version = "0.2.1"
 description = "Profile code regions in python, optionally with LIKWID markers."
 readme = "README.md"
 keywords = [ "python" ]

--- a/src/scope_profiler/__init__.py
+++ b/src/scope_profiler/__init__.py
@@ -1,6 +1,13 @@
 """scope-profiler: lightweight region-based profiling for Python and HPC applications."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from scope_profiler.profile_manager import ProfileManager
+
+try:
+    __version__ = version("scope-profiler")
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 __all__ = [
     "ProfileManager",

--- a/src/scope_profiler/h5reader.py
+++ b/src/scope_profiler/h5reader.py
@@ -35,6 +35,7 @@ class ProfilingH5Reader:
         """
         self._file_path = Path(file_path)
         self._num_ranks = 0
+        self._metadata: dict = {}
         if not self.file_path.exists():
             raise FileNotFoundError(f"HDF5 file not found: {self.file_path}")
 
@@ -42,8 +43,13 @@ class ProfilingH5Reader:
         _region_dict = {}
         region_names = []
         with h5py.File(self.file_path, "r") as f:
+            if "metadata" in f:
+                self._metadata = dict(f["metadata"].attrs)
+
             # Iterate over all rank groups
             for rank_group_name, rank_group in f.items():
+                if rank_group_name == "metadata":
+                    continue
                 self._num_ranks += 1
                 if verbose:
                     print(f"{rank_group_name = }")
@@ -103,6 +109,19 @@ class ProfilingH5Reader:
             The file path as a pathlib.Path object.
         """
         return self._file_path
+
+    @property
+    def metadata(self) -> dict:
+        """
+        Get environment metadata for the run (gathered from rank 0).
+
+        Returns
+        -------
+        dict
+            Metadata dict (hostname, OpenMP thread count, platform, versions,
+            etc.), or an empty dict if the file predates metadata collection.
+        """
+        return self._metadata
 
     @property
     def num_ranks(self) -> int:

--- a/src/scope_profiler/metadata.py
+++ b/src/scope_profiler/metadata.py
@@ -1,0 +1,75 @@
+"""Collects descriptive metadata about the environment a profiling run executed in."""
+
+import ctypes
+import datetime
+import getpass
+import os
+import platform
+import socket
+from typing import Dict, Union
+
+MetadataValue = Union[str, int]
+
+# Common OpenMP runtime library names across platforms/compilers.
+_OMP_LIBRARY_NAMES = (
+    "libomp.so",
+    "libgomp.so.1",
+    "libiomp5.so",
+    "libomp.dylib",
+    "libiomp5.dylib",
+)
+
+
+def _detect_omp_num_threads() -> int:
+    """Best-effort detection of the number of OpenMP threads available.
+
+    Tries to query the OpenMP runtime directly via ``omp_get_max_threads``,
+    so the recorded value is correct even when ``OMP_NUM_THREADS`` is unset
+    (OpenMP then defaults to the number of available cores rather than 1).
+    Falls back to the ``OMP_NUM_THREADS`` environment variable, then to 1.
+    """
+    for libname in _OMP_LIBRARY_NAMES:
+        try:
+            lib = ctypes.CDLL(libname)
+            return int(lib.omp_get_max_threads())
+        except (OSError, AttributeError):
+            continue
+
+    env_value = os.environ.get("OMP_NUM_THREADS")
+    if env_value:
+        try:
+            # OMP_NUM_THREADS may be a comma-separated list for nested
+            # parallelism; the first value is the outermost level.
+            return int(env_value.split(",")[0].strip())
+        except ValueError:
+            pass
+
+    return 1
+
+
+def collect_metadata() -> Dict[str, MetadataValue]:
+    """Gather metadata describing the current run's environment.
+
+    Returns
+    -------
+    dict
+        Mapping of metadata field name to a str or int value, suitable for
+        storing as HDF5 attributes.
+    """
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        scope_profiler_version = version("scope-profiler")
+    except PackageNotFoundError:
+        scope_profiler_version = "unknown"
+
+    return {
+        "timestamp": datetime.datetime.now().isoformat(),
+        "hostname": socket.gethostname(),
+        "platform": platform.platform(),
+        "python_version": platform.python_version(),
+        "scope_profiler_version": scope_profiler_version,
+        "working_directory": os.getcwd(),
+        "omp_num_threads": _detect_omp_num_threads(),
+        "user": getpass.getuser(),
+    }

--- a/src/scope_profiler/profile_config.py
+++ b/src/scope_profiler/profile_config.py
@@ -5,6 +5,8 @@ import tempfile
 from time import perf_counter_ns
 from typing import TYPE_CHECKING
 
+from scope_profiler.metadata import collect_metadata
+
 if TYPE_CHECKING:
     from mpi4py.MPI import Intercomm
 
@@ -132,6 +134,10 @@ class ProfilingConfig:
         # Temporary file with rank-specific timings
         self._local_file_path = self.get_local_filepath(self._rank)
 
+        # Environment metadata (hostname, OpenMP threads, versions, ...),
+        # collected per rank since it can differ across nodes/processes.
+        self._metadata = collect_metadata()
+
         self._pylikwid = None
         if self.use_likwid:
             # pylikwid.markerinit()
@@ -222,3 +228,8 @@ class ProfilingConfig:
     def config_creation_time(self) -> int:
         """Timestamp (ns) when the configuration was created."""
         return self._config_creation_time
+
+    @property
+    def metadata(self) -> dict:
+        """Environment metadata for this rank (hostname, OpenMP threads, ...)."""
+        return self._metadata

--- a/src/scope_profiler/profile_manager.py
+++ b/src/scope_profiler/profile_manager.py
@@ -388,6 +388,11 @@ class ProfileManager:
         if rank == 0:
             merged_file_path = config.file_path
             with h5py.File(merged_file_path, "w") as fout:
+                # Global environment metadata, gathered from rank 0 only.
+                meta_grp = fout.create_group("metadata")
+                for key, value in config.metadata.items():
+                    meta_grp.attrs[key] = value
+
                 for r in range(size):
                     rank_file = config.get_local_filepath(r)
                     if not os.path.exists(rank_file):

--- a/src/scope_profiler/tests/test_app.py
+++ b/src/scope_profiler/tests/test_app.py
@@ -1,9 +1,12 @@
+import socket
 from time import sleep
 
+import h5py
 import pytest
 
 import scope_profiler.tests.examples as examples
 from scope_profiler import ProfileManager
+from scope_profiler.h5reader import ProfilingH5Reader
 from scope_profiler.region_profiler import (
     DisabledProfileRegion,
     FullProfileRegion,
@@ -352,6 +355,42 @@ def test_recursive_profile_setup_default_and_override():
     assert helper_name not in regions
 
     ProfileManager.finalize(verbose=False)
+
+
+def test_finalize_writes_global_metadata(tmp_path):
+    file_path = tmp_path / "profiling_metadata.h5"
+    ProfileManager.setup(file_path=str(file_path))
+
+    with ProfileManager.profile_region("region"):
+        pass
+
+    ProfileManager.finalize(verbose=False)
+
+    expected_keys = {
+        "timestamp",
+        "hostname",
+        "platform",
+        "python_version",
+        "scope_profiler_version",
+        "working_directory",
+        "omp_num_threads",
+        "user",
+    }
+
+    with h5py.File(file_path, "r") as f:
+        assert "metadata" in f
+        assert "rank0" in f
+        # Metadata is global (gathered from rank 0 only), not duplicated
+        # per rank.
+        assert "metadata" not in f["rank0"]
+
+        attrs = dict(f["metadata"].attrs)
+        assert expected_keys <= attrs.keys()
+        assert attrs["hostname"] == socket.gethostname()
+        assert attrs["omp_num_threads"] >= 1
+
+    reader = ProfilingH5Reader(file_path)
+    assert reader.metadata == attrs
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The following metadata is now taken from rank 0:

```
"timestamp",
"hostname",
"platform",
"python_version",
"scope_profiler_version",
"working_directory",
"omp_num_threads",
"user",
```